### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/CherubNLP.UnitTest/CherubNLP.UnitTest.csproj
+++ b/CherubNLP.UnitTest/CherubNLP.UnitTest.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.2.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@Oceania2018, I found an issue in the CherubNLP.UnitTest.csproj:

Packages Microsoft.Extensions.Configuration.Binder v3.1.6, Microsoft.Extensions.Configuration.Json v3.1.6, Microsoft.NET.Test.Sdk v16.6.1 and MSTest.TestAdapter v2.1.2 transitively introduce  85 dependencies into CherubNLP’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/CherubNLP.html)), while Microsoft.Extensions.Configuration.Binder v3.1.7, Microsoft.Extensions.Configuration.Json v3.1.8, Microsoft.NET.Test.Sdk v16.7.1 and MSTest.TestAdapter v2.2.1 can only introduce 53 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/CherubNLP_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose